### PR TITLE
Modernize plugin services and controllers for Craft 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^3.4.0"
+    "php": "^8.0.2",
+    "craftcms/cms": "^4.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Characteristic.php
+++ b/src/Characteristic.php
@@ -20,6 +20,7 @@ use craft\helpers\UrlHelper;
 use craft\services\Elements;
 use craft\services\Fields;
 use craft\services\UserPermissions;
+use craft\web\Response;
 use craft\web\twig\variables\Cp;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
@@ -50,41 +51,41 @@ class Characteristic extends Plugin
 {
     // Static Properties
     // =========================================================================
-    const PERMISSION_EDIT_GROUP = 'editCharacteristicGroup';
+    public const PERMISSION_EDIT_GROUP = 'editCharacteristicGroup';
 
-    /**
-     * @var Characteristic
-     */
-    public static $plugin;
+    public static ?self $plugin = null;
 
     // Public Properties
     // =========================================================================
 
-    public $hasCpSettings = true;
-    public $hasCpSection = true;
+    public bool $hasCpSettings = true;
+    public bool $hasCpSection = true;
 
-    /**
-     * @var string
-     */
     // 1.0.0.2 = 1.0.0-beta.11
-    public $schemaVersion = '1.0.0.2';
+    public string $schemaVersion = '1.0.0.2';
 
     // Public Methods
     // =========================================================================
 
+    public static function config(): array
+    {
+        return [
+            'components' => [
+                'characteristicGroups' => ['class' => CharacteristicGroups::class],
+                'characteristics' => ['class' => Characteristics::class],
+                'characteristicValues' => ['class' => CharacteristicValues::class],
+                'characteristicLinkBlocks' => ['class' => CharacteristicLinkBlocks::class],
+            ],
+        ];
+    }
+
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         self::$plugin = $this;
-        $this->setComponents([
-            'characteristicGroups' => CharacteristicGroups::class,
-            'characteristics' => Characteristics::class,
-            'characteristicValues' => CharacteristicValues::class,
-            'characteristicLinkBlocks' => CharacteristicLinkBlocks::class,
-        ]);
 
         $this->_registerCpRoutes();
         $this->_registerProjectConfig();
@@ -93,33 +94,36 @@ class Characteristic extends Plugin
         $this->_registerVariables();
         $this->_registerPermissions();
 
-        Event::on(Cp::class, Cp::EVENT_REGISTER_CP_SETTINGS,
-            function (RegisterCpSettingsEvent $e) {
-                $e->settings['Content']['characteristics'] = [
+        Event::on(
+            Cp::class,
+            Cp::EVENT_REGISTER_CP_SETTINGS,
+            function (RegisterCpSettingsEvent $event) {
+                $event->settings['Content']['characteristics'] = [
                     'icon' => $this->cpNavIconPath(),
                     'url' => 'settings/characteristics',
-                    'label' => 'Characteristics'
+                    'label' => Craft::t('characteristic', 'Characteristics'),
                 ];
-            });
+            }
+        );
     }
 
-    public function getSettingsResponse()
+    public function getSettingsResponse(): ?Response
     {
-        return Craft::$app->response->redirect(UrlHelper::cpUrl('settings/characteristics'));
+        return Craft::$app->getResponse()->redirect(UrlHelper::cpUrl('settings/characteristics'));
     }
 
-    public function getCpNavItem()
+    public function getCpNavItem(): ?array
     {
         if (count(static::$plugin->characteristicGroups->getAllGroups())) {
             $navItem = parent::getCpNavItem();
-            $navItem['label'] = 'Characteristics';
+            $navItem['label'] = Craft::t('characteristic', 'Characteristics');
             $navItem['url'] = UrlHelper::cpUrl('characteristics');
             return $navItem;
         }
         return null;
     }
 
-    private function _registerCpRoutes()
+    private function _registerCpRoutes(): void
     {
         Event::on(
             UrlManager::class,
@@ -141,7 +145,7 @@ class Characteristic extends Plugin
         );
     }
 
-    private function _registerProjectConfig()
+    private function _registerProjectConfig(): void
     {
         Craft::$app->projectConfig
             ->onAdd('characteristicGroups.{uid}', [$this->characteristicGroups, 'handleChangedGroup'])
@@ -149,7 +153,7 @@ class Characteristic extends Plugin
             ->onRemove('characteristicGroups.{uid}', [$this->characteristicGroups, 'handleDeletedGroup']);
     }
 
-    private function _registerElementTypes()
+    private function _registerElementTypes(): void
     {
         Event::on(
             Elements::class,
@@ -162,7 +166,7 @@ class Characteristic extends Plugin
         );
     }
 
-    private function _registerFieldTypes()
+    private function _registerFieldTypes(): void
     {
         Event::on(
             Fields::class,
@@ -173,7 +177,7 @@ class Characteristic extends Plugin
         );
     }
 
-    private function _registerVariables()
+    private function _registerVariables(): void
     {
         Event::on(CraftVariable::class, CraftVariable::EVENT_INIT,
             function (Event $event) {
@@ -184,17 +188,34 @@ class Characteristic extends Plugin
         );
     }
 
-    private function _registerPermissions()
+    private function _registerPermissions(): void
     {
-        Event::on(UserPermissions::class, UserPermissions::EVENT_REGISTER_PERMISSIONS, function (RegisterUserPermissionsEvent $event) {
-            $groups = self::getInstance()->characteristicGroups->getAllGroups();
-            foreach($groups as $group) {
-                $permissions = [];
-                $permissions[self::PERMISSION_EDIT_GROUP .':'. $group->uid] = [
-                    'label' => Craft::t('characteristic', 'Edit ' . $group->name)
-                ];
-                $event->permissions[Craft::t('characteristic', 'Characteristic Group - '. $group->name)] = $permissions;
+        Event::on(
+            UserPermissions::class,
+            UserPermissions::EVENT_REGISTER_PERMISSIONS,
+            function (RegisterUserPermissionsEvent $event) {
+                $plugin = self::$plugin;
+                if ($plugin === null) {
+                    return;
+                }
+
+                $groups = $plugin->characteristicGroups->getAllGroups();
+
+                foreach ($groups as $group) {
+                    $event->permissions[] = [
+                        'heading' => Craft::t('characteristic', 'Characteristic Group - {groupName}', [
+                            'groupName' => $group->name,
+                        ]),
+                        'permissions' => [
+                            self::PERMISSION_EDIT_GROUP . ':' . $group->uid => [
+                                'label' => Craft::t('characteristic', 'Edit {groupName}', [
+                                    'groupName' => $group->name,
+                                ]),
+                            ],
+                        ],
+                    ];
+                }
             }
-        });
+        );
     }
 }

--- a/src/controllers/CharacteristicValuesController.php
+++ b/src/controllers/CharacteristicValuesController.php
@@ -32,7 +32,7 @@ class CharacteristicValuesController extends Controller
     // Public Methods
     // =========================================================================
 
-    public function actionEditValue(string $groupHandle, int $characteristicId = null, int $valueId = null, CharacteristicValue $value = null): Response
+    public function actionEditValue(string $groupHandle, ?int $characteristicId = null, ?int $valueId = null, ?CharacteristicValue $value = null): Response
     {
         $variables = [
             'characteristicId' => $characteristicId,
@@ -94,7 +94,7 @@ class CharacteristicValuesController extends Controller
         return $this->renderTemplate('characteristic/characteristics/_edit-value', $variables);
     }
 
-    private function _prepEditCharacteristicValueVariables(array &$variables)
+    private function _prepEditCharacteristicValueVariables(array &$variables): ?Response
     {
         // Get the value
         // ---------------------------------------------------------------------
@@ -146,8 +146,15 @@ class CharacteristicValuesController extends Controller
         if (!is_array($valueIds)) {
             throw new Exception('Expected array of ids');
         }
+        $valueIds = array_map('intval', $valueIds);
         Plugin::$plugin->characteristicValues->reorderValues($valueIds);
-        return $this->asJson(['success' => true]);
+
+        return $this->asSuccess(
+            Craft::t('characteristic', 'Characteristic values reordered.'),
+            data: [
+                'ids' => $valueIds,
+            ]
+        );
     }
 
     /**
@@ -162,20 +169,24 @@ class CharacteristicValuesController extends Controller
 
         $valueId = Craft::$app->getRequest()->getRequiredBodyParam('id');
 
-        Plugin::$plugin->characteristicValues->deleteValueById($valueId);
+        Plugin::$plugin->characteristicValues->deleteValueById((int)$valueId);
 
-        return $this->asJson(['success' => true]);
+        return $this->asSuccess(
+            Craft::t('characteristic', 'Characteristic value deleted.'),
+            data: [
+                'id' => (int)$valueId,
+            ]
+        );
     }
 
     /**
      * Saves an entry.
      *
-     * @param bool $duplicate Whether the entry should be duplicated
      * @return Response|null
      * @throws ServerErrorHttpException if reasons
      * @throws NotFoundHttpException
      */
-    public function actionSaveValue()
+    public function actionSaveValue(): ?Response
     {
         $this->requirePostRequest();
 
@@ -187,45 +198,35 @@ class CharacteristicValuesController extends Controller
 
 
         if (!Craft::$app->getElements()->saveElement($characteristicValue)) {
-            if ($request->getAcceptsJson()) {
-                return $this->asJson([
-                    'errors' => $characteristicValue->getErrors(),
-                ]);
-            }
-
-            Craft::$app->getSession()->setError(Craft::t('characteristic', 'Couldn’t save characteristic value.'));
-
-            // Send the entry back to the template
-            Craft::$app->getUrlManager()->setRouteParams([
-                'value' => $characteristicValue
-            ]);
-
-            return null;
+            return $this->asModelFailure(
+                $characteristicValue,
+                Craft::t('characteristic', 'Couldn’t save characteristic value.'),
+                'value'
+            );
         }
 
-        if ($request->getAcceptsJson()) {
-            $return = [];
+        $data = [
+            'id' => $characteristicValue->id,
+            'value' => $characteristicValue->value,
+            'dateCreated' => DateTimeHelper::toIso8601($characteristicValue->dateCreated),
+            'dateUpdated' => DateTimeHelper::toIso8601($characteristicValue->dateUpdated),
+        ];
 
-            $return['success'] = true;
-            $return['id'] = $characteristicValue->id;
-            $return['value'] = $characteristicValue->value;
-
-            if ($request->getIsCpRequest()) {
-                $return['cpEditUrl'] = $characteristicValue->getCpEditUrl();
-            }
-
-            $return['dateCreated'] = DateTimeHelper::toIso8601($characteristicValue->dateCreated);
-            $return['dateUpdated'] = DateTimeHelper::toIso8601($characteristicValue->dateUpdated);
-
-            return $this->asJson($return);
+        if ($request->getIsCpRequest()) {
+            $data['cpEditUrl'] = $characteristicValue->getCpEditUrl();
         }
 
-        Craft::$app->getSession()->setNotice(Craft::t('app', 'Characteristic value saved.'));
-
-        return $this->redirectToPostedUrl($characteristicValue);
+        return $this->asModelSuccess(
+            $characteristicValue,
+            Craft::t('characteristic', 'Characteristic value saved.'),
+            routeParams: [
+                'value' => $characteristicValue,
+            ],
+            data: $data
+        );
     }
 
-    private function _getValueModel()
+    private function _getValueModel(): CharacteristicValue
     {
         $request = Craft::$app->getRequest();
         $valueId = $request->getBodyParam('valueId');
@@ -256,7 +257,7 @@ class CharacteristicValuesController extends Controller
         return $value;
     }
 
-    private function _populateCharacteristicValueModel(CharacteristicValue $value)
+    private function _populateCharacteristicValueModel(CharacteristicValue $value): void
     {
         $request = Craft::$app->getRequest();
 

--- a/src/controllers/CharacteristicsController.php
+++ b/src/controllers/CharacteristicsController.php
@@ -41,9 +41,9 @@ class CharacteristicsController extends Controller
     /**
      * @return mixed
      */
-    public function actionIndex()
+    public function actionIndex(): Response
     {
-        Craft::$app->view->registerAssetBundle(CharacteristicElement::class);
+        Craft::$app->getView()->registerAssetBundle(CharacteristicElement::class);
         return $this->renderTemplate('characteristic/characteristics/_index', []);
     }
 
@@ -58,7 +58,7 @@ class CharacteristicsController extends Controller
      * @throws ForbiddenHttpException
      * @throws NotFoundHttpException if the requested site handle is invalid
      */
-    public function actionEditCharacteristic(string $groupHandle, int $characteristicId = null, Characteristic $characteristic = null): Response
+    public function actionEditCharacteristic(string $groupHandle, ?int $characteristicId = null, ?Characteristic $characteristic = null): Response
     {
         $variables = [
             'groupHandle' => $groupHandle,
@@ -129,7 +129,7 @@ class CharacteristicsController extends Controller
      * @throws NotFoundHttpException if the requested group or characteristic cannot be found
      * @throws ForbiddenHttpException if the user is not permitted to edit content in the requested site
      */
-    private function _prepEditCharacteristicVariables(array &$variables)
+    private function _prepEditCharacteristicVariables(array &$variables): ?Response
     {
         // Get the characteristic
         // ---------------------------------------------------------------------
@@ -190,7 +190,7 @@ class CharacteristicsController extends Controller
      * @throws ElementNotFoundException
      * @throws Exception
      */
-    public function actionSaveCharacteristic(bool $duplicate = false)
+    public function actionSaveCharacteristic(bool $duplicate = false): ?Response
     {
         $this->requirePostRequest();
 
@@ -199,44 +199,34 @@ class CharacteristicsController extends Controller
 
         $this->_populateCharacteristicModel($characteristic);
 
-
         if (!Craft::$app->getElements()->saveElement($characteristic)) {
-            if ($request->getAcceptsJson()) {
-                return $this->asJson([
-                    'errors' => $characteristic->getErrors(),
-                ]);
-            }
-
-            Craft::$app->getSession()->setError(Craft::t('characteristic', 'Couldn’t save characteristic.'));
-
-            Craft::$app->getUrlManager()->setRouteParams([
-                'characteristic' => $characteristic
-            ]);
-
-            return null;
+            return $this->asModelFailure(
+                $characteristic,
+                Craft::t('characteristic', 'Couldn’t save characteristic.'),
+                'characteristic'
+            );
         }
 
-        if ($request->getAcceptsJson()) {
-            $return = [];
+        $data = [
+            'id' => $characteristic->id,
+            'title' => $characteristic->title,
+            'handle' => $characteristic->handle,
+            'dateCreated' => DateTimeHelper::toIso8601($characteristic->dateCreated),
+            'dateUpdated' => DateTimeHelper::toIso8601($characteristic->dateUpdated),
+        ];
 
-            $return['success'] = true;
-            $return['id'] = $characteristic->id;
-            $return['title'] = $characteristic->title;
-            $return['handle'] = $characteristic->handle;
-
-            if ($request->getIsCpRequest()) {
-                $return['cpEditUrl'] = $characteristic->getCpEditUrl();
-            }
-
-            $return['dateCreated'] = DateTimeHelper::toIso8601($characteristic->dateCreated);
-            $return['dateUpdated'] = DateTimeHelper::toIso8601($characteristic->dateUpdated);
-
-            return $this->asJson($return);
+        if ($request->getIsCpRequest()) {
+            $data['cpEditUrl'] = $characteristic->getCpEditUrl();
         }
 
-        Craft::$app->getSession()->setNotice(Craft::t('app', 'Characteristic saved.'));
-
-        return $this->redirectToPostedUrl($characteristic);
+        return $this->asModelSuccess(
+            $characteristic,
+            Craft::t('characteristic', 'Characteristic saved.'),
+            routeParams: [
+                'characteristic' => $characteristic,
+            ],
+            data: $data
+        );
     }
 
     /**
@@ -271,7 +261,7 @@ class CharacteristicsController extends Controller
      *
      * @param Characteristic $characteristic
      */
-    private function _populateCharacteristicModel(Characteristic $characteristic)
+    private function _populateCharacteristicModel(Characteristic $characteristic): void
     {
         $request = Craft::$app->getRequest();
 
@@ -290,7 +280,7 @@ class CharacteristicsController extends Controller
      * @throws ServerErrorHttpException if reasons
      * @since 3.2.3
      */
-    public function actionDuplicateCharacteristic()
+    public function actionDuplicateCharacteristic(): ?Response
     {
         return $this->runAction('save-characteristic', ['duplicate' => true]);
     }
@@ -304,40 +294,28 @@ class CharacteristicsController extends Controller
      * @throws MissingComponentException
      * @throws BadRequestHttpException
      */
-    public function actionDeleteCharacteristic()
+    public function actionDeleteCharacteristic(): ?Response
     {
         $this->requirePostRequest();
 
-        $request = Craft::$app->getRequest();
-        $characteristicId = $request->getRequiredBodyParam('characteristicId');
+        $characteristicId = Craft::$app->getRequest()->getRequiredBodyParam('characteristicId');
         $characteristic = Plugin::$plugin->characteristics->getCharacteristicById($characteristicId);
 
         if (!$characteristic) {
             throw new NotFoundHttpException('Characteristic not found');
         }
 
-        $currentUser = Craft::$app->getUser()->getIdentity();
-
         if (!Craft::$app->getElements()->deleteElement($characteristic)) {
-            if ($request->getAcceptsJson()) {
-                return $this->asJson(['success' => false]);
-            }
-
-            Craft::$app->getSession()->setError(Craft::t('characteristic', 'Couldn’t delete characteristic.'));
-
-            Craft::$app->getUrlManager()->setRouteParams([
-                'characteristic' => $characteristic
-            ]);
-
-            return null;
+            return $this->asFailure(Craft::t('characteristic', 'Couldn’t delete characteristic.'));
         }
 
-        if ($request->getAcceptsJson()) {
-            return $this->asJson(['success' => true]);
-        }
-
-        Craft::$app->getSession()->setNotice(Craft::t('characteristic', 'Characteristic deleted.'));
-
-        return $this->redirectToPostedUrl($characteristic);
+        return $this->asSuccess(
+            Craft::t('characteristic', 'Characteristic deleted.'),
+            data: [
+                'id' => $characteristic->id,
+                'title' => $characteristic->title,
+                'handle' => $characteristic->handle,
+            ]
+        );
     }
 }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -31,7 +31,7 @@ class SettingsController extends Controller
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         // All section actions require an admin
         $this->requireAdmin();
@@ -53,7 +53,7 @@ class SettingsController extends Controller
     }
 
 
-    public function actionEditGroup(int $groupId = null, CharacteristicGroup $group = null): Response
+    public function actionEditGroup(int $groupId = null, ?CharacteristicGroup $group = null): Response
     {
         $variables = [
             'groupId' => $groupId,
@@ -124,7 +124,7 @@ class SettingsController extends Controller
      * @throws SectionNotFoundException
      * @throws ForbiddenHttpException
      */
-    public function actionSaveGroup()
+    public function actionSaveGroup(): ?Response
     {
         $this->requirePostRequest();
         $this->requireAdmin();
@@ -153,19 +153,25 @@ class SettingsController extends Controller
 
         // Save it
         if (!Characteristic::$plugin->characteristicGroups->saveGroup($group)) {
-            Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t save group.'));
-
-            // Send the section back to the template
-            Craft::$app->getUrlManager()->setRouteParams([
-                'group' => $group
-            ]);
-
-            return null;
+            return $this->asModelFailure(
+                $group,
+                Craft::t('app', 'Couldn’t save group.'),
+                'group'
+            );
         }
 
-        Craft::$app->getSession()->setNotice(Craft::t('characteristic', 'Characteristic group saved.'));
-
-        return $this->redirectToPostedUrl($group);
+        return $this->asModelSuccess(
+            $group,
+            Craft::t('characteristic', 'Characteristic group saved.'),
+            routeParams: [
+                'group' => $group,
+            ],
+            data: [
+                'id' => $group->id,
+                'name' => $group->name,
+                'handle' => $group->handle,
+            ]
+        );
     }
 
     /**
@@ -182,6 +188,11 @@ class SettingsController extends Controller
 
         Characteristic::$plugin->characteristicGroups->deleteGroupById($groupId);
 
-        return $this->asJson(['success' => true]);
+        return $this->asSuccess(
+            Craft::t('characteristic', 'Characteristic group deleted.'),
+            data: [
+                'id' => (int)$groupId,
+            ]
+        );
     }
 }

--- a/src/models/CharacteristicGroup.php
+++ b/src/models/CharacteristicGroup.php
@@ -17,6 +17,7 @@ use craft\helpers\StringHelper;
 use craft\models\FieldLayout;
 use craft\validators\HandleValidator;
 use craft\validators\UniqueValidator;
+use DateTime;
 use venveo\characteristic\elements\Characteristic;
 use venveo\characteristic\elements\CharacteristicValue;
 use venveo\characteristic\records\CharacteristicGroup as CharacteristicGroupRecord;
@@ -37,50 +38,27 @@ class CharacteristicGroup extends Model
     // =========================================================================
 
 
-    /**
-     * @var int|null ID
-     */
-    public $id;
+    public ?int $id = null;
 
-    /**
-     * @var string|null Name
-     */
-    public $name;
+    public ?string $name = null;
 
-    /**
-     * @var string|null Handle
-     */
-    public $handle;
+    public ?string $handle = null;
 
-    /** @var boolean */
-    public $allowCustomOptionsByDefault = true;
+    public bool $allowCustomOptionsByDefault = true;
 
-    /** @var boolean */
-    public $requiredByDefault = false;
+    public bool $requiredByDefault = false;
 
-    /**
-     * @var string|null Group's UID
-     */
-    public $uid;
+    public ?string $uid = null;
 
-    /**
-     * @var int|null ID
-     */
-    public $characteristicFieldLayoutId;
+    public ?int $characteristicFieldLayoutId = null;
 
-    /**
-     * @var int|null ID
-     */
-    public $valueFieldLayoutId;
+    public ?int $valueFieldLayoutId = null;
 
-    /**
-     * @var int|null Structure ID
-     */
-    public $structureId;
+    public ?int $structureId = null;
 
-    public $dateCreated;
+    public ?DateTime $dateCreated = null;
 
-    public $dateUpdated;
+    public ?DateTime $dateUpdated = null;
 
     // Public Methods
     // =========================================================================
@@ -119,7 +97,7 @@ class CharacteristicGroup extends Model
         return $rules;
     }
 
-    public function getDataForProjectConfig($structureUid = null)
+    public function getDataForProjectConfig(?string $structureUid = null): array
     {
 
         $generateLayoutConfig = function (FieldLayout $fieldLayout): array {


### PR DESCRIPTION
## Summary
- require PHP 8.0.2 to align with Craft 4 runtime expectations
- refactor the plugin bootstrap to use `config()` and Craft 4 permission registration APIs
- update controllers and models with typed properties and Craft 4 response helpers

## Testing
- php -l src/Characteristic.php
- php -l src/controllers/CharacteristicsController.php
- php -l src/controllers/CharacteristicValuesController.php
- php -l src/controllers/SettingsController.php
- php -l src/models/CharacteristicGroup.php

------
https://chatgpt.com/codex/tasks/task_e_68e97025ca9c8330ac40fe28769fb78f