### PR TITLE
Refactor characteristic element editing to unified Craft 4 UI

### DIFF
--- a/src/Characteristic.php
+++ b/src/Characteristic.php
@@ -12,14 +12,19 @@ namespace venveo\characteristic;
 
 use Craft;
 use craft\base\Plugin;
+use craft\events\DefineFieldLayoutFieldsEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterCpSettingsEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\fieldlayoutelements\LightswitchField;
+use craft\fieldlayoutelements\TextField;
+use craft\fieldlayoutelements\TitleField;
 use craft\helpers\UrlHelper;
 use craft\services\Elements;
 use craft\services\Fields;
 use craft\services\UserPermissions;
+use craft\models\FieldLayout;
 use craft\web\Response;
 use craft\web\twig\variables\Cp;
 use craft\web\twig\variables\CraftVariable;
@@ -93,6 +98,7 @@ class Characteristic extends Plugin
         $this->_registerFieldTypes();
         $this->_registerVariables();
         $this->_registerPermissions();
+        $this->_registerFieldLayoutElements();
 
         Event::on(
             Cp::class,
@@ -135,12 +141,64 @@ class Characteristic extends Plugin
 
                 $event->rules['characteristics'] = 'characteristic/characteristics/index';
                 $event->rules['characteristics/<groupHandle:{handle}>'] = 'characteristic/characteristics/index';
-                $event->rules['characteristics/save-characteristic'] = 'characteristic/characteristics/save-characteristic';
-                $event->rules['characteristics/<groupHandle:{handle}>/new'] = 'characteristic/characteristics/edit-characteristic';
+                $event->rules['characteristics/<groupHandle:{handle}>/new'] = [
+                    'route' => 'elements/edit',
+                    'defaults' => ['elementType' => CharacteristicElement::class],
+                ];
 
-                $event->rules['characteristics/<groupHandle:{handle}>/<characteristicId:\d+>'] = 'characteristic/characteristics/edit-characteristic';
+                $event->rules['characteristics/<groupHandle:{handle}>/<elementId:\d+>'] = [
+                    'route' => 'elements/edit',
+                    'defaults' => ['elementType' => CharacteristicElement::class],
+                ];
                 $event->rules['characteristics/<groupHandle:{handle}>/<characteristicId:\d+>/<valueId:\d+>'] = 'characteristic/characteristic-values/edit-value';
                 $event->rules['characteristics/<groupHandle:{handle}>/<characteristicId:\d+>/new'] = 'characteristic/characteristic-values/edit-value';
+            }
+        );
+    }
+
+    private function _registerFieldLayoutElements(): void
+    {
+        Event::on(
+            FieldLayout::class,
+            FieldLayout::EVENT_DEFINE_NATIVE_FIELDS,
+            function(DefineFieldLayoutFieldsEvent $event) {
+                $fieldLayout = $event->sender;
+
+                if ($fieldLayout->type !== CharacteristicElement::class) {
+                    return;
+                }
+
+                $event->fields[] = new TitleField([
+                    'mandatory' => true,
+                    'label' => Craft::t('app', 'Title'),
+                    'instructions' => Craft::t('characteristic', 'Enter a descriptive name for the characteristic.'),
+                ]);
+
+                $event->fields[] = new TextField([
+                    'attribute' => 'handle',
+                    'label' => Craft::t('app', 'Handle'),
+                    'mandatory' => true,
+                    'instructions' => Craft::t('characteristic', 'How you’ll reference this characteristic in your templates.'),
+                ]);
+
+                $event->fields[] = new LightswitchField([
+                    'attribute' => 'allowCustomOptions',
+                    'label' => Craft::t('characteristic', 'Allow custom options'),
+                    'instructions' => Craft::t('characteristic', 'Whether editors can provide custom values for this characteristic.'),
+                ]);
+
+                $event->fields[] = new LightswitchField([
+                    'attribute' => 'required',
+                    'label' => Craft::t('characteristic', 'Required'),
+                    'instructions' => Craft::t('characteristic', 'Whether elements must include a value for this characteristic.'),
+                ]);
+
+                $event->fields[] = new TextField([
+                    'attribute' => 'maxValues',
+                    'label' => Craft::t('characteristic', 'Maximum values'),
+                    'instructions' => Craft::t('characteristic', 'Limit the number of values that can be selected, or leave blank for unlimited.'),
+                    'type' => 'number',
+                ]);
             }
         );
     }

--- a/src/elements/Characteristic.php
+++ b/src/elements/Characteristic.php
@@ -19,7 +19,12 @@ use craft\elements\actions\Duplicate;
 use craft\elements\actions\Restore;
 use craft\elements\db\ElementQueryInterface;
 use craft\helpers\UrlHelper;
+use craft\elements\User;
+use craft\fieldlayoutelements\LightswitchField;
+use craft\fieldlayoutelements\TextField;
+use craft\fieldlayoutelements\TitleField;
 use craft\models\FieldLayout;
+use craft\models\FieldLayoutTab;
 use venveo\characteristic\Characteristic as Plugin;
 use venveo\characteristic\elements\CharacteristicLinkBlock;
 use venveo\characteristic\elements\db\CharacteristicQuery;
@@ -257,9 +262,33 @@ class Characteristic extends Element
     /**
      * @inheritdoc
      */
-    public function getIsEditable(): bool
+    public function canView(User $user): bool
     {
-        return true;
+        return $this->_canManage($user);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canSave(User $user): bool
+    {
+        return $this->_canManage($user);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canDuplicate(User $user): bool
+    {
+        return $this->_canManage($user);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canDelete(User $user): bool
+    {
+        return $this->_canManage($user);
     }
 
     /**
@@ -267,7 +296,23 @@ class Characteristic extends Element
      */
     public function getFieldLayout(): ?FieldLayout
     {
-        return parent::getFieldLayout() ?? $this->getGroup()->getCharacteristicFieldLayout();
+        $fieldLayout = parent::getFieldLayout();
+
+        if ($fieldLayout !== null && $fieldLayout->getTabs()) {
+            return $fieldLayout;
+        }
+
+        try {
+            $groupLayout = $this->getGroup()->getCharacteristicFieldLayout();
+        } catch (InvalidConfigException $exception) {
+            return $this->_createDefaultFieldLayout();
+        }
+
+        if ($groupLayout->getTabs()) {
+            return $groupLayout;
+        }
+
+        return $this->_createDefaultFieldLayout();
     }
 
     /**
@@ -308,30 +353,6 @@ class Characteristic extends Element
         $url = UrlHelper::cpUrl('characteristics/' . $group->handle . '/' . $this->id);
 
         return $url;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getEditorHtml(): string
-    {
-        $html = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'textField', [
-            [
-                'label' => Craft::t('app', 'Title'),
-                'siteId' => $this->siteId,
-                'id' => 'title',
-                'name' => 'title',
-                'value' => $this->title,
-                'errors' => $this->getErrors('title'),
-                'first' => true,
-                'autofocus' => true,
-                'required' => true
-            ]
-        ]);
-
-        $html .= parent::getEditorHtml();
-
-        return $html;
     }
 
     /**
@@ -391,6 +412,74 @@ class Characteristic extends Element
         }
 
         return $this->_hasNewParent = $this->_checkForNewParent();
+    }
+
+    private function _canManage(User $user): bool
+    {
+        try {
+            $group = $this->getGroup();
+        } catch (InvalidConfigException $exception) {
+            return false;
+        }
+
+        if ($group->uid === null) {
+            return false;
+        }
+
+        return $user->can(Plugin::PERMISSION_EDIT_GROUP . ':' . $group->uid);
+    }
+
+    private function _createDefaultFieldLayout(): FieldLayout
+    {
+        $fieldLayout = new FieldLayout();
+        $fieldLayout->type = static::class;
+
+        $contentElements = [
+            new TitleField([
+                'mandatory' => true,
+                'label' => Craft::t('app', 'Title'),
+            ]),
+        ];
+
+        $settingsElements = [
+            new TextField([
+                'attribute' => 'handle',
+                'label' => Craft::t('app', 'Handle'),
+                'mandatory' => true,
+            ]),
+            new LightswitchField([
+                'attribute' => 'allowCustomOptions',
+                'label' => Craft::t('characteristic', 'Allow custom options'),
+            ]),
+            new LightswitchField([
+                'attribute' => 'required',
+                'label' => Craft::t('characteristic', 'Required'),
+            ]),
+            new TextField([
+                'attribute' => 'maxValues',
+                'label' => Craft::t('characteristic', 'Maximum values'),
+                'type' => 'number',
+            ]),
+        ];
+
+        $tabs = [];
+
+        $contentTab = new FieldLayoutTab();
+        $contentTab->name = Craft::t('app', 'Content');
+        $contentTab->setLayout($fieldLayout);
+        $contentTab->setElements($contentElements);
+        $tabs[] = $contentTab;
+
+        $settingsTab = new FieldLayoutTab();
+        $settingsTab->name = Craft::t('app', 'Settings');
+        $settingsTab->setLayout($fieldLayout);
+        $settingsTab->setElements($settingsElements);
+        $tabs[] = $settingsTab;
+
+        $fieldLayout->setTabs($tabs);
+        $fieldLayout->setElements(array_merge($contentElements, $settingsElements));
+
+        return $fieldLayout;
     }
 
     // Events

--- a/src/models/CharacteristicGroup.php
+++ b/src/models/CharacteristicGroup.php
@@ -10,11 +10,16 @@
 
 namespace venveo\characteristic\models;
 
+use Craft;
 use craft\base\Model;
 use craft\behaviors\FieldLayoutBehavior;
 use craft\helpers\Db;
 use craft\helpers\StringHelper;
+use craft\fieldlayoutelements\LightswitchField;
+use craft\fieldlayoutelements\TextField;
+use craft\fieldlayoutelements\TitleField;
 use craft\models\FieldLayout;
+use craft\models\FieldLayoutTab;
 use craft\validators\HandleValidator;
 use craft\validators\UniqueValidator;
 use DateTime;
@@ -142,7 +147,13 @@ class CharacteristicGroup extends Model
     {
         /** @var FieldLayoutBehavior $behavior */
         $behavior = $this->getBehavior('characteristicFieldLayout');
-        return $behavior->getFieldLayout();
+        $fieldLayout = $behavior->getFieldLayout();
+
+        if (!$fieldLayout->getTabs()) {
+            $fieldLayout = $this->_createDefaultCharacteristicFieldLayout();
+        }
+
+        return $fieldLayout;
     }
 
     /**
@@ -154,5 +165,58 @@ class CharacteristicGroup extends Model
         /** @var FieldLayoutBehavior $behavior */
         $behavior = $this->getBehavior('valueFieldLayout');
         return $behavior->getFieldLayout();
+    }
+
+    private function _createDefaultCharacteristicFieldLayout(): FieldLayout
+    {
+        $fieldLayout = new FieldLayout();
+        $fieldLayout->type = Characteristic::class;
+
+        $contentElements = [
+            new TitleField([
+                'mandatory' => true,
+                'label' => Craft::t('app', 'Title'),
+            ]),
+        ];
+
+        $settingsElements = [
+            new TextField([
+                'attribute' => 'handle',
+                'label' => Craft::t('app', 'Handle'),
+                'mandatory' => true,
+            ]),
+            new LightswitchField([
+                'attribute' => 'allowCustomOptions',
+                'label' => Craft::t('characteristic', 'Allow custom options'),
+            ]),
+            new LightswitchField([
+                'attribute' => 'required',
+                'label' => Craft::t('characteristic', 'Required'),
+            ]),
+            new TextField([
+                'attribute' => 'maxValues',
+                'label' => Craft::t('characteristic', 'Maximum values'),
+                'type' => 'number',
+            ]),
+        ];
+
+        $tabs = [];
+
+        $contentTab = new FieldLayoutTab();
+        $contentTab->name = Craft::t('app', 'Content');
+        $contentTab->setLayout($fieldLayout);
+        $contentTab->setElements($contentElements);
+        $tabs[] = $contentTab;
+
+        $settingsTab = new FieldLayoutTab();
+        $settingsTab->name = Craft::t('app', 'Settings');
+        $settingsTab->setLayout($fieldLayout);
+        $settingsTab->setElements($settingsElements);
+        $tabs[] = $settingsTab;
+
+        $fieldLayout->setTabs($tabs);
+        $fieldLayout->setElements(array_merge($contentElements, $settingsElements));
+
+        return $fieldLayout;
     }
 }


### PR DESCRIPTION
## Summary
- route characteristic edit routes through Craft's unified `elements/edit` controller and register native field layout elements for the editor
- add permission-aware element guards and programmatic default layouts so characteristics render via field layout elements
- seed new characteristic groups with a default field layout matching the new editor structure

## Testing
- php -l src/Characteristic.php
- php -l src/elements/Characteristic.php
- php -l src/models/CharacteristicGroup.php

------
https://chatgpt.com/codex/tasks/task_e_68fbed0246048330a84658f4c9f8d6ca