### PR TITLE
fix: Characteristics field blocks Craft 4 live-entry saves (must be an array)

### DIFF
--- a/src/fields/Characteristics.php
+++ b/src/fields/Characteristics.php
@@ -23,7 +23,6 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\ElementHelper;
 use craft\helpers\Html;
 use craft\services\Elements;
-use craft\validators\ArrayValidator;
 use Exception;
 use Throwable;
 use Twig\Error\LoaderError;
@@ -350,13 +349,16 @@ class Characteristics extends Field implements EagerLoadingFieldInterface
      */
     public function getElementValidationRules(): array
     {
+        // NOTE: This field's value normalizes to a CharacteristicLinkBlockQuery (an
+        // ElementQuery). In Craft 3, ElementQuery implemented Countable, so an
+        // ArrayValidator on SCENARIO_LIVE passed. In Craft 4, craft\db\Query no longer
+        // declares the Countable interface (it has count() but does not implement
+        // Countable), so craft\validators\ArrayValidator rejects the query with
+        // "{attribute} must be an array." on every live-entry save. The validator was
+        // only ever a vestigial "is array-like" guard with no min/max, so it is removed.
+        // Real validation (required characteristics) lives in validateCharacteristicData().
         return [
             'validateCharacteristicData',
-            [
-                ArrayValidator::class,
-                'skipOnEmpty' => false,
-                'on' => Element::SCENARIO_LIVE,
-            ],
         ];
     }
 
@@ -396,7 +398,14 @@ class Characteristics extends Field implements EagerLoadingFieldInterface
 
 
         $source = ElementHelper::findSource(CharacteristicElement::class, $this->source, 'index');
-        $groupId = $source['criteria']['groupId'];
+        $groupId = $source['criteria']['groupId'] ?? null;
+        if ($groupId === null) {
+            // The element source can't always be resolved (e.g. outside a control
+            // panel request, such as console validation). Without a group we can't
+            // determine which characteristics are required, so skip the check rather
+            // than dereferencing a null source.
+            return;
+        }
 
         $required = CharacteristicElement::find()->groupId($groupId)->required(true)->indexBy('id')->with(['values'])->all();
         if ($required) {


### PR DESCRIPTION
## Problem

Saving any live entry whose field layout includes a Characteristics field fails in the control panel with:

> Part Page Characteristics must be an array.

This blocks content editors from updating those entries at all (reported on the Basco parts store, where editing a `partListingPages` entry was impossible regardless of what was changed).

## Root cause

The field's value normalizes to a `CharacteristicLinkBlockQuery` (an `ElementQuery`). `getElementValidationRules()` applies a `craft\validators\ArrayValidator` to that value on `SCENARIO_LIVE`.

In **Craft 3**, `ElementQuery` implemented `Countable`, so the validator passed. In **Craft 4**, `craft\db\Query` no longer declares the `Countable` interface (it still has a `count()` method, but does not `implement Countable`), so `ArrayValidator` rejects the query because it is neither an array nor `instanceof Countable`, and adds the "must be an array" error on every live save.

Verified at runtime against the production database:

```
class:                venveo\characteristic\elements\db\CharacteristicLinkBlockQuery
instanceof Countable: NO
is_array:             NO
count() works:        7 blocks
```

The rule is byte-identical to the released `beta.12`, so it was not introduced by the Craft 4 port; Craft core's interface change silently broke it.

## Changes

- **Remove the `ArrayValidator` rule** from `getElementValidationRules()`. It was a vestigial "is array-like" guard with no `min`/`max`, so it did no real work even when it passed. The meaningful validation (required characteristics) already lives in `validateCharacteristicData()`.
- **Guard `validateCharacteristicData()` against a null element source** so it no longer dereferences `null` (`$source['criteria']['groupId']`) when the source cannot be resolved outside a CP request (surfaced during console validation).
- Drop the now-unused `ArrayValidator` import.

## Verification

Applied to a local Basco install (Craft 4, production DB clone) and saved the previously-broken entry through the control panel: **"Entry saved."** with no validation error. The underlying characteristic data was confirmed clean, so no data migration is required, only this code fix.

## Scope / deploy note

This affects every live entry with a Characteristics field, so it is worth shipping to all Craft 4 sites consuming this plugin. Basco currently tracks the `codex/fix-php-compile-error-in-characteristics-plugin` branch via `dev-` composer constraint, which is why this PR targets that branch.

https://claude.ai/code/session_01D5Ueqf5oz3iivo8QzM8Zf8
