### PR TITLE
fix: Craft 4 value-editor 500 + CharacteristicQuery defects

### DIFF
--- a/src/elements/Characteristic.php
+++ b/src/elements/Characteristic.php
@@ -312,30 +312,6 @@ class Characteristic extends Element
 
     /**
      * @inheritdoc
-     */
-    public function getEditorHtml(): string
-    {
-        $html = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'textField', [
-            [
-                'label' => Craft::t('app', 'Title'),
-                'siteId' => $this->siteId,
-                'id' => 'title',
-                'name' => 'title',
-                'value' => $this->title,
-                'errors' => $this->getErrors('title'),
-                'first' => true,
-                'autofocus' => true,
-                'required' => true
-            ]
-        ]);
-
-        $html .= parent::getEditorHtml();
-
-        return $html;
-    }
-
-    /**
-     * @inheritdoc
      * @throws Exception if reasons
      */
     public function afterSave(bool $isNew): void

--- a/src/elements/db/CharacteristicQuery.php
+++ b/src/elements/db/CharacteristicQuery.php
@@ -119,17 +119,18 @@ class CharacteristicQuery extends ElementQuery
         $this->_applyGroupIdParam();
 
         if ($this->handle) {
-            if (is_array($this->handle)) {
-                $this->subQuery->andWhere('in', Db::parseParam('characteristic_characteristics.handle', $this->handle));
-            } else {
-                $this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.handle', $this->handle));
-            }
+            // Db::parseParam() already returns a complete condition for both scalars
+            // and arrays, so a single andWhere() handles both. The previous
+            // andWhere('in', ...) form passed 'in' as the whole condition and produced
+            // invalid SQL when $handle was an array.
+            $this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.handle', $this->handle));
         }
         if ($this->required !== null) {
             $this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.required', $this->required));
         }
         if ($this->allowCustomOptions !== null) {
-            $this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.allowCustomOptions', $this->required));
+            // Was filtering against $this->required (wrong column param).
+            $this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.allowCustomOptions', $this->allowCustomOptions));
         }
 
         return parent::beforePrepare();

--- a/src/templates/characteristics/_edit-value.twig
+++ b/src/templates/characteristics/_edit-value.twig
@@ -7,6 +7,12 @@
 {% set groupHandle = characteristic.group.handle %}
 {% set isNewValue = value.id ? false : true %}
 
+{# Craft 4's _layouts/cp no longer defines a `contextMenu` block, so define an
+   empty one locally before referencing it below (mirrors _edit.twig). Without
+   this, `block('contextMenu')` falls through to the layout and throws
+   "Block contextMenu on template _layouts/base does not exist." #}
+{% block contextMenu %}{% endblock %}
+
 {% block header %}
     <div class="flex flex-nowrap">
         {{ block('pageTitle') }}


### PR DESCRIPTION
Follow-up to #85. While auditing the Craft 4 port for other regressions of the same kind as the `ArrayValidator` bug, I found and fixed three issues, verified on a local install (Craft 4, production DB clone).

## 1. Characteristic value editor returns a 500 (live, user-facing)

Editing **or** creating a characteristic value 500'd:

> Twig\Error\RuntimeError: Block "contextMenu" on template "_layouts/base" does not exist. in templates/characteristics/_edit-value.twig:13

Craft 4's `_layouts/cp` no longer defines a `contextMenu` block, but `_edit-value.twig` references `{{ block('contextMenu') }}` in its `header` override. The sibling `_edit.twig` already works because it defines an empty `{% block contextMenu %}{% endblock %}` stub; `_edit-value.twig` was missing it. Fix mirrors the sibling.

This blocked managing characteristic value options entirely through the CP (e.g. adding new option values to a characteristic).

## 2. `CharacteristicQuery` `allowCustomOptions` filter uses the wrong param

```php
// before
$this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.allowCustomOptions', $this->required));
// after
$this->subQuery->andWhere(Db::parseParam('characteristic_characteristics.allowCustomOptions', $this->allowCustomOptions));
```
`Characteristic::find()->allowCustomOptions(...)` filtered the correct column against the value of `$this->required`. (Latent: not exercised inside the plugin today, but wrong for any caller.)

## 3. `CharacteristicQuery` malformed `andWhere('in', ...)` for array handles

`Db::parseParam()` already returns a complete condition for both scalars and arrays, so the `is_array($this->handle)` branch calling `andWhere('in', Db::parseParam(...))` passed `'in'` as the whole WHERE condition and produced invalid SQL whenever `handle` was queried with an array. Collapsed to the single correct `andWhere(Db::parseParam(...))`.

## 4. Remove dead `Characteristic::getEditorHtml()` override

It called `craft\web\View::renderTemplateMacro()` and `parent::getEditorHtml()`, both **removed** in Craft 4. Craft 4 never invokes `getEditorHtml()` (editor UI comes from the field layout), so this was a latent fatal rather than a live one. Removed.

## Verification

On a local install with the production DB, all of these now load without error: the Characteristics index, edit-characteristic, **new value**, and **edit value** pages.

## Not included here (recommended follow-up)

A separate review pass flagged a family of edge-case null-deref / robustness issues (reorder with a stale value id, editing a value under a non-existent characteristic id, an unchecked `saveElement()` in `getValueElement()`, an eager-load null path in `CharacteristicValue::setEagerLoadedElements`, a broken `Exception` message arg, and an unguarded project-config `structure` key in `handleChangedGroup`), plus ~10 deprecated `anyStatus()` calls that should become `status(null)`. None break the happy path; happy to roll them into this PR or a separate hardening PR.

https://claude.ai/code/session_01D5Ueqf5oz3iivo8QzM8Zf8
